### PR TITLE
upgraded coinmaster

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -113,12 +113,12 @@ import (
 	ibcclientclient "github.com/cosmos/ibc-go/v3/modules/core/02-client/client"
 	ibcclienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	coinmastermodule "github.com/noria-net/noria/x/coinmaster"
+	coinmasterbindings "github.com/noria-net/noria/x/coinmaster/bindings"
 	coinmastermodulekeeper "github.com/noria-net/noria/x/coinmaster/keeper"
 	coinmastermoduletypes "github.com/noria-net/noria/x/coinmaster/types"
-	coinmastermodulewasm "github.com/noria-net/noria/x/coinmaster/wasm"
 
 	"github.com/CosmWasm/token-factory/x/tokenfactory"
-	"github.com/CosmWasm/token-factory/x/tokenfactory/bindings"
+	tokenfactorybindings "github.com/CosmWasm/token-factory/x/tokenfactory/bindings"
 	tokenfactorykeeper "github.com/CosmWasm/token-factory/x/tokenfactory/keeper"
 	tokenfactorytypes "github.com/CosmWasm/token-factory/x/tokenfactory/types"
 
@@ -554,10 +554,8 @@ func NewWasmApp(
 	// if we want to allow any custom callbacks
 	supportedFeatures := "iterator,staking,stargate,coinmaster,cosmwasm_1_1,token_factory"
 
-	encoders := wasmkeeper.DefaultEncoders(appCodec, app.transferKeeper)
-	mergedEncoders := encoders.Merge(coinmastermodulewasm.NewMessageEncoders())
-	wasmOpts = append(wasmOpts, wasmkeeper.WithMessageEncoders(&mergedEncoders))
-	wasmOpts = append(wasmOpts, bindings.RegisterCustomPlugins(&app.bankKeeper, &app.TokenFactoryKeeper)...)
+	wasmOpts = append(wasmOpts, tokenfactorybindings.RegisterCustomPlugins(&app.bankKeeper, &app.TokenFactoryKeeper)...)
+	wasmOpts = append(wasmOpts, coinmasterbindings.RegisterCustomPlugins(&app.CoinmasterKeeper)...)
 
 	app.wasmKeeper = wasm.NewKeeper(
 		appCodec,

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
@@ -74,6 +75,7 @@ require (
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,7 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -452,6 +453,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbskOL6tDC5jMSyx3zxE=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=

--- a/proto/coinmaster/tx.proto
+++ b/proto/coinmaster/tx.proto
@@ -9,25 +9,25 @@ option go_package = "github.com/noria-net/noria/x/coinmaster/types";
 
 // Msg defines the Msg service.
 service Msg {
-      rpc Mint(MsgMint) returns (MsgMintResponse);
-  rpc Burn(MsgBurn) returns (MsgBurnResponse);
+  rpc Mint(MsgCoinmasterMint) returns (MsgCoinmasterMintResponse);
+  rpc Burn(MsgCoinmasterBurn) returns (MsgCoinmasterBurnResponse);
 // this line is used by starport scaffolding # proto/tx/rpc
 }
 
-message MsgMint {
+message MsgCoinmasterMint {
   string creator = 1;
   cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];
 }
 
-message MsgMintResponse {
+message MsgCoinmasterMintResponse {
 }
 
-message MsgBurn {
+message MsgCoinmasterBurn {
   string creator = 1;
   cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];
 }
 
-message MsgBurnResponse {
+message MsgCoinmasterBurnResponse {
 }
 
 // this line is used by starport scaffolding # proto/tx/message

--- a/testutil/keeper/coinmaster.go
+++ b/testutil/keeper/coinmaster.go
@@ -53,7 +53,10 @@ func NewCoinmasterKeeperWithBankKeeper(t testing.TB, bankKeeper types.BankKeeper
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
 
 	// Initialize params
-	k.SetParams(ctx, types.DefaultParams())
+	err := k.SetParams(ctx, types.DefaultParams())
+	if err != nil {
+		panic(err)
+	}
 
 	return k, ctx
 }

--- a/util/string.go
+++ b/util/string.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func SplitStringIntoAddresses(str string) ([]sdk.AccAddress, error) {
+	regex := (`^([a-z0-9]{40,80},)*[a-z0-9]{40,80}$`)
+
+	if match, err := regexp.MatchString(regex, str); !match || err != nil {
+		return nil, errors.New("invalid addresses")
+	}
+
+	var addresses = []sdk.AccAddress{}
+
+	for _, addr := range strings.Split(str, ",") {
+		validAddr, err := sdk.AccAddressFromBech32(addr)
+		if err != nil {
+			return nil, err
+		}
+		addresses = append(addresses, validAddr)
+	}
+	return addresses, nil
+}
+
+func SplitStringIntoDenoms(str string) ([]string, error) {
+	regex := `^([a-zA-Z0-9]{3,64},)*[a-zA-Z0-9]{3,64}$`
+
+	if match, err := regexp.MatchString(regex, str); !match || err != nil {
+		return nil, errors.New("invalid denoms")
+	}
+
+	return strings.Split(str, ","), nil
+}

--- a/x/coinmaster/README.md
+++ b/x/coinmaster/README.md
@@ -1,0 +1,154 @@
+# Coinmaster Module
+
+Coinmaster is a custom Cosmos SDK module that allows for the creation, minting, and burning of custom tokens. It can be used in conjunction with the CosmWasm smart contract platform.
+
+## Permission
+
+The **Coinmaster** module has two guards in place:
+
+- Whitelisted denominations, a comma-separated string of denominations. You can only mint/burn whitelisted denoms. The initial whitelist is set to an empty string, which allows minting and burning any denomination. This can be changed through governance with a `param-change` proposal such as:
+
+```bash
+{
+  "title": "Update whitelisted denominations",
+  "description": "Update whitelisted denominations",
+  "changes": [
+    {
+      "subspace": "coinmaster",
+      "key": "Denoms",
+      "value": "ucrd,unoria,nwbtc"
+    }
+  ],
+  "deposit": "1000000unoria"
+}
+```
+
+- Whitelisted minters, a comma-sepratated string of account addresses (smart contract supported). Only Minters are allowed to mint/burn coins. This can be changed through governance with a `param-change` proposal such as:
+
+```bash
+{
+  "title": "Update whitelisted minters",
+  "description": "Update whitelisted minters",
+  "changes": [
+    {
+      "subspace": "coinmaster",
+      "key": "Minters",
+      "value": "noria1qrh465lh5ygkaqu0nc2wdxfv5nkmwl3xlqf7jl"
+    }
+  ],
+  "deposit": "1000000unoria"
+}
+```
+
+The default value of the minter is an empty string, which allows anyone to mint/burn.
+
+## Minting
+
+```bash
+noriad tx coinmaster mint \
+1000000ucrd \
+--from="myWalletName" \
+--gas="auto" \
+--gas-prices="0.0025ucrd" \
+--gas-adjustment="1.5" \
+--chain-id="oasis-3"
+```
+
+## Burning
+
+```bash
+noriad tx coinmaster burn \
+1000000ucrd \
+--from="myWalletName" \
+--gas="auto" \
+--gas-prices="0.0025ucrd" \
+--gas-adjustment="1.5" \
+--chain-id="oasis-3"
+```
+
+## Wasm Bindings
+
+The Coinmaster module can be used in conjunction with CosmWasm smart contracts. The following is an example of how to use the module in a smart contract:
+
+```rust
+// Types
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    Mint { amount: String },
+    Burn { amount: String },
+}
+
+#[cw_serde]
+/// A number of Custom messages that can call into the Noria custom modules bindings
+pub enum NoriaMsg {
+    Coinmaster(CoinmasterMsg),
+}
+
+#[cw_serde]
+/// A number of Custom messages that can call into the Coinmaster bindings
+pub enum CoinmasterMsg {
+    Mint { amount: String },
+    Burn { amount: String },
+}
+
+impl From<NoriaMsg> for CosmosMsg<NoriaMsg> {
+    fn from(msg: NoriaMsg) -> CosmosMsg<NoriaMsg> {
+        CosmosMsg::Custom(msg)
+    }
+}
+
+impl CustomMsg for NoriaMsg {}
+```
+
+```rust
+// Execute mint
+let mint_msg = NoriaMsg::Coinmaster(CoinmasterMsg::Mint {
+    amount: String::from("1000000ucrd"),
+});
+
+let res = Response::new()
+    .add_message(mint_msg);
+```
+
+```json
+// expected payload
+{
+  "coinmaster": {
+    "mint": {
+      "amount": "1000000ucrd"
+    }
+  }
+}
+```
+
+```rust
+// Execute burn
+let burn_msg = NoriaMsg::Coinmaster(CoinmasterMsg::Burn {
+    amount: String::from("1000000ucrd"),
+});
+
+let res = Response::new()
+    .add_message(burn_msg);
+```
+
+```json
+// expected payload
+{
+  "coinmaster": {
+    "burn": {
+      "amount": "1000000ucrd"
+    }
+  }
+}
+```
+
+## Protobuf
+
+```protobuf
+
+package norianet.noria.coinmaster;
+
+// Protobuf value for MsgCoinmasterMint: /norianet.noria.coinmaster.MsgCoinmasterMint
+// Protobuf value for MsgCoinmasterBurn: /norianet.noria.coinmaster.MsgCoinmasterBurn
+```

--- a/x/coinmaster/bindings/message_plugin.go
+++ b/x/coinmaster/bindings/message_plugin.go
@@ -1,0 +1,132 @@
+package bindings
+
+import (
+	"encoding/json"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	coinmasterkeeper "github.com/noria-net/noria/x/coinmaster/keeper"
+	coinmastertypes "github.com/noria-net/noria/x/coinmaster/types"
+)
+
+// CustomMessageDecorator returns decorator for custom CosmWasm bindings messages
+func CustomMessageDecorator(coinmaster *coinmasterkeeper.Keeper) func(wasmkeeper.Messenger) wasmkeeper.Messenger {
+	return func(old wasmkeeper.Messenger) wasmkeeper.Messenger {
+		return &CustomMessenger{
+			wrapped:    old,
+			coinmaster: coinmaster,
+		}
+	}
+}
+
+type CustomMessenger struct {
+	wrapped    wasmkeeper.Messenger
+	coinmaster *coinmasterkeeper.Keeper
+}
+
+var _ wasmkeeper.Messenger = (*CustomMessenger)(nil)
+
+// DispatchMsg executes on the contractMsg.
+func (m *CustomMessenger) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) ([]sdk.Event, [][]byte, error) {
+	if msg.Custom != nil {
+		// only handle the happy path where this is really creating / minting / swapping ...
+		// leave everything else for the wrapped version
+		var contractMsg coinmastertypes.CoinmasterMsg
+		if err := json.Unmarshal(msg.Custom, &contractMsg); err != nil {
+			return nil, nil, sdkerrors.Wrap(err, "coinmaster msg")
+		}
+		if contractMsg.Coinmaster == nil {
+			// return nil, nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "nil coinmaster field")
+			return m.wrapped.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)
+		}
+		coinmasterMsg := contractMsg.Coinmaster
+
+		if coinmasterMsg.Mint != nil {
+			return m.mint(ctx, contractAddr, coinmasterMsg.Mint)
+		}
+		if coinmasterMsg.Burn != nil {
+			return m.burn(ctx, contractAddr, coinmasterMsg.Burn)
+		}
+	}
+	return m.wrapped.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)
+}
+
+// mint
+func (m *CustomMessenger) mint(ctx sdk.Context, contractAddr sdk.AccAddress, msg *coinmastertypes.MsgCustomCoinmasterMint) ([]sdk.Event, [][]byte, error) {
+	bz, err := PerformMint(m.coinmaster, ctx, contractAddr, msg)
+	if err != nil {
+		return nil, nil, sdkerrors.Wrap(err, "perform mint denom")
+	}
+	return nil, [][]byte{bz}, nil
+}
+
+func PerformMint(f *coinmasterkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, msg *coinmastertypes.MsgCustomCoinmasterMint) ([]byte, error) {
+	if msg == nil {
+		return nil, wasmvmtypes.InvalidRequest{Err: "nil mint message"}
+	}
+
+	msgServer := coinmasterkeeper.NewMsgServerImpl(*f)
+
+	coins, err := sdk.ParseCoinNormalized(msg.Amount)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "coinmaster mint")
+	}
+
+	msgMint := coinmastertypes.NewMsgCoinmasterMint(contractAddr.String(), coins)
+
+	if err := msgMint.ValidateBasic(); err != nil {
+		return nil, sdkerrors.Wrap(err, "failed validating MsgCoinmasterMint")
+	}
+
+	resp, err := msgServer.Mint(
+		sdk.WrapSDKContext(ctx),
+		msgMint,
+	)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "coinmaster mint")
+	}
+
+	return resp.Marshal()
+}
+
+// burn tokens
+func (m *CustomMessenger) burn(ctx sdk.Context, contractAddr sdk.AccAddress, msg *coinmastertypes.MsgCustomCoinmasterBurn) ([]sdk.Event, [][]byte, error) {
+	bz, err := PerformBurn(m.coinmaster, ctx, contractAddr, msg)
+	if err != nil {
+		return nil, nil, sdkerrors.Wrap(err, "perform burn denom")
+	}
+	return nil, [][]byte{bz}, nil
+}
+
+func PerformBurn(f *coinmasterkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, msg *coinmastertypes.MsgCustomCoinmasterBurn) ([]byte, error) {
+	if msg == nil {
+		return nil, wasmvmtypes.InvalidRequest{Err: "nil burn message"}
+	}
+
+	msgServer := coinmasterkeeper.NewMsgServerImpl(*f)
+
+	coins, err := sdk.ParseCoinNormalized(msg.Amount)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "coinmaster mint")
+	}
+
+	msgBurn := coinmastertypes.NewMsgCoinmasterBurn(contractAddr.String(), coins)
+
+	if err := msgBurn.ValidateBasic(); err != nil {
+		return nil, sdkerrors.Wrap(err, "failed validating MsgCoinmasterMint")
+	}
+
+	// Create denom
+	resp, err := msgServer.Burn(
+		sdk.WrapSDKContext(ctx),
+		msgBurn,
+	)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "coinmaster burn")
+	}
+
+	return resp.Marshal()
+}

--- a/x/coinmaster/bindings/queries.go
+++ b/x/coinmaster/bindings/queries.go
@@ -1,0 +1,29 @@
+package bindings
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	coinmasterkeeper "github.com/noria-net/noria/x/coinmaster/keeper"
+	coinmastertypes "github.com/noria-net/noria/x/coinmaster/types"
+)
+
+type QueryPlugin struct {
+	coinmasterKeeper *coinmasterkeeper.Keeper
+}
+
+// NewQueryPlugin returns a reference to a new QueryPlugin.
+func NewQueryPlugin(k *coinmasterkeeper.Keeper) *QueryPlugin {
+	return &QueryPlugin{
+		coinmasterKeeper: k,
+	}
+}
+
+func (qp QueryPlugin) GetParams(ctx sdk.Context) (*coinmastertypes.ParamsResponse, error) {
+	params := qp.coinmasterKeeper.GetParams(ctx)
+	return &coinmastertypes.ParamsResponse{
+		Params: coinmastertypes.Params{
+			Minters: params.Minters,
+			Denoms:  params.Denoms,
+		},
+	}, nil
+}

--- a/x/coinmaster/bindings/queries.go
+++ b/x/coinmaster/bindings/queries.go
@@ -21,7 +21,7 @@ func NewQueryPlugin(k *coinmasterkeeper.Keeper) *QueryPlugin {
 func (qp QueryPlugin) GetParams(ctx sdk.Context) (*coinmastertypes.ParamsResponse, error) {
 	params := qp.coinmasterKeeper.GetParams(ctx)
 	return &coinmastertypes.ParamsResponse{
-		Params: coinmastertypes.Params{
+		Params: coinmastertypes.ParamsProperties{
 			Minters: params.Minters,
 			Denoms:  params.Denoms,
 		},

--- a/x/coinmaster/bindings/query_plugin.go
+++ b/x/coinmaster/bindings/query_plugin.go
@@ -1,0 +1,44 @@
+package bindings
+
+import (
+	"encoding/json"
+	"fmt"
+
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	coinmastertypes "github.com/noria-net/noria/x/coinmaster/types"
+)
+
+// CustomQuerier dispatches custom CosmWasm bindings queries.
+func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessage) ([]byte, error) {
+	return func(ctx sdk.Context, request json.RawMessage) ([]byte, error) {
+		var contractQuery coinmastertypes.CoinmasterQuery
+		if err := json.Unmarshal(request, &contractQuery); err != nil {
+			return nil, sdkerrors.Wrap(err, "coinmaster query")
+		}
+		if contractQuery.Coinmaster == nil {
+			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "nil coinmaster field")
+		}
+		coinmasterMsg := contractQuery.Coinmaster
+
+		switch {
+		case coinmasterMsg.Params != nil:
+			res, err := qp.GetParams(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			bz, err := json.Marshal(res)
+			if err != nil {
+				return nil, fmt.Errorf("failed to JSON marshal ParamsResponse: %w", err)
+			}
+
+			return bz, nil
+
+		default:
+			return nil, wasmvmtypes.UnsupportedRequest{Kind: "unknown coinmaster query variant"}
+		}
+	}
+}

--- a/x/coinmaster/bindings/query_plugin.go
+++ b/x/coinmaster/bindings/query_plugin.go
@@ -2,7 +2,6 @@ package bindings
 
 import (
 	"encoding/json"
-	"fmt"
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,7 +15,7 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 	return func(ctx sdk.Context, request json.RawMessage) ([]byte, error) {
 		var contractQuery coinmastertypes.CoinmasterQuery
 		if err := json.Unmarshal(request, &contractQuery); err != nil {
-			return nil, sdkerrors.Wrap(err, "coinmaster query")
+			return nil, sdkerrors.Wrap(coinmastertypes.ErrCoinmasterQuery, "failed to parse coinmaster query")
 		}
 		if contractQuery.Coinmaster == nil {
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "nil coinmaster field")
@@ -32,7 +31,7 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 
 			bz, err := json.Marshal(res)
 			if err != nil {
-				return nil, fmt.Errorf("failed to JSON marshal ParamsResponse: %w", err)
+				return nil, sdkerrors.Wrap(coinmastertypes.ErrCoinmasterQuery, "failed to marshall coinmaster ParamsResponse")
 			}
 
 			return bz, nil

--- a/x/coinmaster/bindings/wasm.go
+++ b/x/coinmaster/bindings/wasm.go
@@ -1,0 +1,27 @@
+package bindings
+
+import (
+	"github.com/CosmWasm/wasmd/x/wasm"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+
+	coinmasterkeeper "github.com/noria-net/noria/x/coinmaster/keeper"
+)
+
+func RegisterCustomPlugins(
+	coinmasterKeeper *coinmasterkeeper.Keeper,
+) []wasmkeeper.Option {
+	wasmQueryPlugin := NewQueryPlugin(coinmasterKeeper)
+
+	queryPluginOpt := wasmkeeper.WithQueryPlugins(&wasmkeeper.QueryPlugins{
+		Custom: CustomQuerier(wasmQueryPlugin),
+	})
+	messengerDecoratorOpt := wasmkeeper.WithMessageHandlerDecorator(
+		CustomMessageDecorator(coinmasterKeeper),
+	)
+
+	return []wasm.Option{
+		queryPluginOpt,
+		messengerDecoratorOpt,
+	}
+}

--- a/x/coinmaster/client/cli/tx_burn.go
+++ b/x/coinmaster/client/cli/tx_burn.go
@@ -25,7 +25,7 @@ func CmdBurn() *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgBurn(
+			msg := types.NewMsgCoinmasterBurn(
 				clientCtx.GetFromAddress().String(),
 				argAmount,
 			)

--- a/x/coinmaster/client/cli/tx_mint.go
+++ b/x/coinmaster/client/cli/tx_mint.go
@@ -25,7 +25,7 @@ func CmdMint() *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgMint(
+			msg := types.NewMsgCoinmasterMint(
 				clientCtx.GetFromAddress().String(),
 				argAmount,
 			)

--- a/x/coinmaster/genesis.go
+++ b/x/coinmaster/genesis.go
@@ -10,7 +10,10 @@ import (
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
-	k.SetParams(ctx, genState.Params)
+	err := k.SetParams(ctx, genState.Params)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // ExportGenesis returns the capability module's exported genesis.

--- a/x/coinmaster/handler.go
+++ b/x/coinmaster/handler.go
@@ -17,10 +17,10 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 		ctx = ctx.WithEventManager(sdk.NewEventManager())
 
 		switch msg := msg.(type) {
-		case *types.MsgMint:
+		case *types.MsgCoinmasterMint:
 			res, err := msgServer.Mint(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
-		case *types.MsgBurn:
+		case *types.MsgCoinmasterBurn:
 			res, err := msgServer.Burn(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
 			// this line is used by starport scaffolding # 1

--- a/x/coinmaster/keeper/errors.go
+++ b/x/coinmaster/keeper/errors.go
@@ -3,4 +3,6 @@ package keeper
 const (
 	Error_unauthorized_account = "unauthorized account"
 	Error_unauthorized_denom   = "unauthorized denomination"
+	Error_invalid_denom        = "invalid denomination"
+	Error_invalid_minter       = "invalid minter"
 )

--- a/x/coinmaster/keeper/keeper.go
+++ b/x/coinmaster/keeper/keeper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/tendermint/tendermint/libs/log"
-	"golang.org/x/exp/slices"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -20,20 +19,6 @@ type Keeper struct {
 	paramstore paramtypes.Subspace
 
 	bankKeeper types.BankKeeper
-}
-
-// Determine whether the requested denom is allowed
-func IsDenomWhiteListed(denoms []string, denom string) bool {
-
-	if len(denoms) == 0 || len(denoms) == 1 && denoms[0] == "" {
-		// Denom is allowed IF
-		//  - there are no denoms in the whitelist
-		//  - OR there is ONE denom and its value is empty
-		return true
-	} else {
-		// ... otherwise the denom must exist in the whitelist as an EXACT match
-		return slices.Contains(denoms, denom)
-	}
 }
 
 // Creates a new Coinmaster keeper instance

--- a/x/coinmaster/keeper/msg_server_burn_test.go
+++ b/x/coinmaster/keeper/msg_server_burn_test.go
@@ -37,7 +37,7 @@ func Test_Burn_BaseCase(t *testing.T) {
 	bankKeeperMock.EXPECT().BurnCoins(ctx, types.ModuleName, sdk.NewCoins(burnAmount)).Return(nil).Once()
 
 	// Base case
-	resp, err := msgServer.Burn(wCtx, &types.MsgBurn{
+	resp, err := msgServer.Burn(wCtx, &types.MsgCoinmasterBurn{
 		Creator: creator,
 		Amount:  burnAmount,
 	})
@@ -70,7 +70,7 @@ func Test_Burn_MultiplePermissableDenoms(t *testing.T) {
 		bankKeeperMock.EXPECT().BurnCoins(ctx, types.ModuleName, sdk.NewCoins(burnAmount)).Return(nil).Once()
 
 		// Base case
-		resp, err := msgServer.Burn(wCtx, &types.MsgBurn{
+		resp, err := msgServer.Burn(wCtx, &types.MsgCoinmasterBurn{
 			Creator: creator,
 			Amount:  burnAmount,
 		})
@@ -95,7 +95,7 @@ func Test_Burn_DenomNotAllowed(t *testing.T) {
 	// Set single minter and single denom
 	k.SetParams(ctx, types.NewParams(creator, "Xnoria"))
 
-	_, err := msgServer.Burn(wCtx, &types.MsgBurn{
+	_, err := msgServer.Burn(wCtx, &types.MsgCoinmasterBurn{
 		Creator: creator,
 		Amount:  mintAmount,
 	})
@@ -107,7 +107,7 @@ func Test_Burn_BurnerNotAllowed(t *testing.T) {
 	k, ctx := keepertest.NewCoinmasterKeeper(t)
 	msgServer := keeper.NewMsgServerImpl(*k)
 	creator := "noria197hfvr6nfd2228xhlyykc234yhwm6tps2drjx8"
-	whitelistedCreator := "noriaWhitelistedCreator"
+	whitelistedCreator := "noria19r3350dnszl6r7r9mtlneccr9p9hpwe6fscgkz"
 	denom := "unoria"
 	wCtx := sdk.WrapSDKContext(ctx)
 
@@ -119,7 +119,7 @@ func Test_Burn_BurnerNotAllowed(t *testing.T) {
 	// Set single minter and single denom
 	k.SetParams(ctx, types.NewParams(whitelistedCreator, "unoria"))
 
-	_, err := msgServer.Burn(wCtx, &types.MsgBurn{
+	_, err := msgServer.Burn(wCtx, &types.MsgCoinmasterBurn{
 		Creator: creator,
 		Amount:  burnAmount,
 	})

--- a/x/coinmaster/keeper/msg_server_mint_test.go
+++ b/x/coinmaster/keeper/msg_server_mint_test.go
@@ -37,7 +37,7 @@ func Test_Mint_BaseCase(t *testing.T) {
 	bankKeeperMock.EXPECT().SendCoinsFromModuleToAccount(ctx, "coinmaster", creatorAccAddress, sdk.NewCoins(mintAmount)).Return(nil).Once()
 
 	// Base case
-	resp, err := msgServer.Mint(wCtx, &types.MsgMint{
+	resp, err := msgServer.Mint(wCtx, &types.MsgCoinmasterMint{
 		Creator: creator,
 		Amount:  mintAmount,
 	})
@@ -70,7 +70,7 @@ func Test_Mint_MultiplePermissableDenoms(t *testing.T) {
 		bankKeeperMock.EXPECT().SendCoinsFromModuleToAccount(ctx, "coinmaster", creatorAccAddress, sdk.NewCoins(mintAmount)).Return(nil).Once()
 
 		// Base case
-		resp, err := msgServer.Mint(wCtx, &types.MsgMint{
+		resp, err := msgServer.Mint(wCtx, &types.MsgCoinmasterMint{
 			Creator: creator,
 			Amount:  mintAmount,
 		})
@@ -95,7 +95,7 @@ func Test_Mint_DenomNotAllowed(t *testing.T) {
 	// Set single minter and single denom
 	k.SetParams(ctx, types.NewParams(creator, "Xnoria"))
 
-	_, err := msgServer.Mint(wCtx, &types.MsgMint{
+	_, err := msgServer.Mint(wCtx, &types.MsgCoinmasterMint{
 		Creator: creator,
 		Amount:  mintAmount,
 	})
@@ -107,7 +107,7 @@ func Test_Mint_MinterNotAllowed(t *testing.T) {
 	k, ctx := keepertest.NewCoinmasterKeeper(t)
 	msgServer := keeper.NewMsgServerImpl(*k)
 	creator := "noria197hfvr6nfd2228xhlyykc234yhwm6tps2drjx8"
-	whitelistedCreator := "noriaWhitelistedCreator"
+	whitelistedCreator := "noria19r3350dnszl6r7r9mtlneccr9p9hpwe6fscgkz"
 	denom := "unoria"
 	wCtx := sdk.WrapSDKContext(ctx)
 
@@ -119,7 +119,7 @@ func Test_Mint_MinterNotAllowed(t *testing.T) {
 	// Set single minter and single denom
 	k.SetParams(ctx, types.NewParams(whitelistedCreator, "unoria"))
 
-	_, err := msgServer.Mint(wCtx, &types.MsgMint{
+	_, err := msgServer.Mint(wCtx, &types.MsgCoinmasterMint{
 		Creator: creator,
 		Amount:  mintAmount,
 	})

--- a/x/coinmaster/keeper/params.go
+++ b/x/coinmaster/keeper/params.go
@@ -1,6 +1,10 @@
 package keeper
 
 import (
+	"errors"
+	"regexp"
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/noria-net/noria/x/coinmaster/types"
 )
@@ -14,8 +18,34 @@ func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 }
 
 // SetParams set the params
-func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
+func (k Keeper) SetParams(ctx sdk.Context, params types.Params) (err error) {
+	if params.Minters != "" {
+		// validate that params.Minters is a comma separated list of addresses
+		mintersRegex := (`^([a-z0-9]{40,80},)*[a-z0-9]{40,80}$`)
+
+		if match, err := regexp.MatchString(mintersRegex, params.Minters); !match || err != nil {
+			return errors.New(Error_invalid_minter)
+		}
+
+		// validate that each minter is a valid address
+		for _, minter := range strings.Split(params.Minters, ",") {
+			_, err := sdk.AccAddressFromBech32(minter)
+			if err != nil {
+				return errors.New(Error_invalid_minter)
+			}
+		}
+	}
+
+	if params.Denoms != "" {
+		// validate that params.Denoms is a comma separated list of denoms
+		denomsRegex := `^([a-zA-Z0-9]{3,64},)*[a-zA-Z0-9]{3,64}$`
+		if match, err := regexp.MatchString(denomsRegex, params.Denoms); !match || err != nil {
+			return errors.New(Error_invalid_denom)
+		}
+	}
+
 	k.paramstore.SetParamSet(ctx, &params)
+	return nil
 }
 
 // Minters returns the Minters param

--- a/x/coinmaster/keeper/params.go
+++ b/x/coinmaster/keeper/params.go
@@ -2,10 +2,9 @@ package keeper
 
 import (
 	"errors"
-	"regexp"
-	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	util "github.com/noria-net/noria/util"
 	"github.com/noria-net/noria/x/coinmaster/types"
 )
 
@@ -18,28 +17,20 @@ func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 }
 
 // SetParams set the params
-func (k Keeper) SetParams(ctx sdk.Context, params types.Params) (err error) {
+func (k Keeper) SetParams(ctx sdk.Context, params types.Params) error {
+	var err error
 	if params.Minters != "" {
 		// validate that params.Minters is a comma separated list of addresses
-		mintersRegex := (`^([a-z0-9]{40,80},)*[a-z0-9]{40,80}$`)
-
-		if match, err := regexp.MatchString(mintersRegex, params.Minters); !match || err != nil {
+		_, err = util.SplitStringIntoAddresses(params.Minters)
+		if err != nil {
 			return errors.New(Error_invalid_minter)
-		}
-
-		// validate that each minter is a valid address
-		for _, minter := range strings.Split(params.Minters, ",") {
-			_, err := sdk.AccAddressFromBech32(minter)
-			if err != nil {
-				return errors.New(Error_invalid_minter)
-			}
 		}
 	}
 
 	if params.Denoms != "" {
 		// validate that params.Denoms is a comma separated list of denoms
-		denomsRegex := `^([a-zA-Z0-9]{3,64},)*[a-zA-Z0-9]{3,64}$`
-		if match, err := regexp.MatchString(denomsRegex, params.Denoms); !match || err != nil {
+		_, err = util.SplitStringIntoDenoms(params.Denoms)
+		if err != nil {
 			return errors.New(Error_invalid_denom)
 		}
 	}

--- a/x/coinmaster/keeper/params_test.go
+++ b/x/coinmaster/keeper/params_test.go
@@ -1,10 +1,13 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	testkeeper "github.com/noria-net/noria/testutil/keeper"
 	"github.com/noria-net/noria/x/coinmaster/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,4 +19,47 @@ func TestGetParams(t *testing.T) {
 
 	require.EqualValues(t, params, k.GetParams(ctx))
 	require.EqualValues(t, params.Minters, k.Minters(ctx))
+}
+
+func TestSetParams(t *testing.T) {
+	k, ctx := testkeeper.NewCoinmasterKeeper(t)
+	invalidMinterMsg := "invalid minter"
+	invalidDenomMsg := "invalid denomination"
+	sdk.GetConfig().SetBech32PrefixForAccount("noria", "noria")
+	addr := "noria197hfvr6nfd2228xhlyykc234yhwm6tps2drjx8"
+
+	// Test invalid Minters parameter
+	params := types.Params{Minters: "invalid"}
+	err := k.SetParams(ctx, params)
+	assert.EqualErrorf(t, err, invalidMinterMsg, "Error should be: %v, got: %v", invalidMinterMsg, err)
+
+	// Test invalid Denoms parameter
+	params = types.Params{Denoms: "no"}
+	err = k.SetParams(ctx, params)
+	assert.EqualErrorf(t, err, invalidDenomMsg, "Error should be: %v, got: %v", invalidDenomMsg, err)
+
+	// Test valid parameters
+	params = types.Params{Minters: addr, Denoms: "btc,eth"}
+	err = k.SetParams(ctx, params)
+	require.NoError(t, err)
+
+	// Test Minters parameter contains invalid address
+	params = types.Params{Minters: fmt.Sprintf("%v,invalid", addr)}
+	err = k.SetParams(ctx, params)
+	assert.EqualErrorf(t, err, invalidMinterMsg, "Error should be: %v, got: %v", invalidMinterMsg, err)
+
+	// Test Denoms parameter contains invalid denomination
+	params = types.Params{Denoms: "btc,n,,"}
+	err = k.SetParams(ctx, params)
+	assert.EqualErrorf(t, err, invalidDenomMsg, "Error should be: %v, got: %v", invalidDenomMsg, err)
+
+	// Test Minters parameter contains multiple addresses
+	params = types.Params{Minters: fmt.Sprintf("%v,%v", addr, addr)}
+	err = k.SetParams(ctx, params)
+	require.NoError(t, err)
+
+	// Test Denoms parameter contains multiple denominations
+	params = types.Params{Denoms: "btc,eth,usdt"}
+	err = k.SetParams(ctx, params)
+	require.NoError(t, err)
 }

--- a/x/coinmaster/keeper/validation.go
+++ b/x/coinmaster/keeper/validation.go
@@ -1,0 +1,46 @@
+package keeper
+
+import (
+	"errors"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/noria-net/noria/x/coinmaster/types"
+	"golang.org/x/exp/slices"
+)
+
+func (k Keeper) ValidateDenoms(ctx sdk.Context, coins sdk.Coins) error {
+	denoms := strings.Split(k.Denoms(ctx), ",")
+	for _, coin := range coins {
+		if !IsDenomWhiteListed(denoms, coin.Denom) {
+			return errors.New(Error_unauthorized_denom)
+		}
+	}
+	return nil
+}
+
+func (k Keeper) ValidateMinter(ctx sdk.Context, minter string) error {
+	minters := k.Minters(ctx)
+	if minters != types.DefaultMinters {
+		minters := strings.Split(minters, ",")
+		if slices.Contains(minters, minter) {
+			return nil
+		}
+		return errors.New(Error_unauthorized_account)
+	}
+	return nil
+}
+
+// Determine whether the requested denom is allowed
+func IsDenomWhiteListed(denoms []string, denom string) bool {
+
+	if len(denoms) == 0 || len(denoms) == 1 && denoms[0] == "" {
+		// Denom is allowed IF
+		//  - there are no denoms in the whitelist
+		//  - OR there is ONE denom and its value is empty
+		return true
+	} else {
+		// ... otherwise the denom must exist in the whitelist as an EXACT match
+		return slices.Contains(denoms, denom)
+	}
+}

--- a/x/coinmaster/module_simulation.go
+++ b/x/coinmaster/module_simulation.go
@@ -24,13 +24,13 @@ var (
 )
 
 const (
-	opWeightMsgMint = "op_weight_msg_mint"
+	opWeightMsgCoinmasterMint = "op_weight_msg_mint"
 	// TODO: Determine the simulation weight value
-	defaultWeightMsgMint int = 100
+	defaultWeightMsgCoinmasterMint int = 100
 
-	opWeightMsgBurn = "op_weight_msg_burn"
+	opWeightMsgCoinmasterBurn = "op_weight_msg_burn"
 	// TODO: Determine the simulation weight value
-	defaultWeightMsgBurn int = 100
+	defaultWeightMsgCoinmasterBurn int = 100
 
 	// this line is used by starport scaffolding # simapp/module/const
 )
@@ -70,26 +70,26 @@ func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	operations := make([]simtypes.WeightedOperation, 0)
 
-	var weightMsgMint int
-	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgMint, &weightMsgMint, nil,
+	var weightMsgCoinmasterMint int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgCoinmasterMint, &weightMsgCoinmasterMint, nil,
 		func(_ *rand.Rand) {
-			weightMsgMint = defaultWeightMsgMint
+			weightMsgCoinmasterMint = defaultWeightMsgCoinmasterMint
 		},
 	)
 	operations = append(operations, simulation.NewWeightedOperation(
-		weightMsgMint,
-		coinmastersimulation.SimulateMsgMint(am.accountKeeper, am.bankKeeper, am.keeper),
+		weightMsgCoinmasterMint,
+		coinmastersimulation.SimulateMsgCoinmasterMint(am.accountKeeper, am.bankKeeper, am.keeper),
 	))
 
-	var weightMsgBurn int
-	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgBurn, &weightMsgBurn, nil,
+	var weightMsgCoinmasterBurn int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgCoinmasterBurn, &weightMsgCoinmasterBurn, nil,
 		func(_ *rand.Rand) {
-			weightMsgBurn = defaultWeightMsgBurn
+			weightMsgCoinmasterBurn = defaultWeightMsgCoinmasterBurn
 		},
 	)
 	operations = append(operations, simulation.NewWeightedOperation(
-		weightMsgBurn,
-		coinmastersimulation.SimulateMsgBurn(am.accountKeeper, am.bankKeeper, am.keeper),
+		weightMsgCoinmasterBurn,
+		coinmastersimulation.SimulateMsgCoinmasterBurn(am.accountKeeper, am.bankKeeper, am.keeper),
 	))
 
 	// this line is used by starport scaffolding # simapp/module/operation

--- a/x/coinmaster/simulation/burn.go
+++ b/x/coinmaster/simulation/burn.go
@@ -10,7 +10,7 @@ import (
 	"github.com/noria-net/noria/x/coinmaster/types"
 )
 
-func SimulateMsgBurn(
+func SimulateMsgCoinmasterBurn(
 	ak types.AccountKeeper,
 	bk types.BankKeeper,
 	k keeper.Keeper,
@@ -18,7 +18,7 @@ func SimulateMsgBurn(
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		simAccount, _ := simtypes.RandomAcc(r, accs)
-		msg := &types.MsgBurn{
+		msg := &types.MsgCoinmasterBurn{
 			Creator: simAccount.Address.String(),
 		}
 

--- a/x/coinmaster/simulation/mint.go
+++ b/x/coinmaster/simulation/mint.go
@@ -10,7 +10,7 @@ import (
 	"github.com/noria-net/noria/x/coinmaster/types"
 )
 
-func SimulateMsgMint(
+func SimulateMsgCoinmasterMint(
 	ak types.AccountKeeper,
 	bk types.BankKeeper,
 	k keeper.Keeper,
@@ -18,7 +18,7 @@ func SimulateMsgMint(
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		simAccount, _ := simtypes.RandomAcc(r, accs)
-		msg := &types.MsgMint{
+		msg := &types.MsgCoinmasterMint{
 			Creator: simAccount.Address.String(),
 		}
 

--- a/x/coinmaster/types/codec.go
+++ b/x/coinmaster/types/codec.go
@@ -8,17 +8,17 @@ import (
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgMint{}, "coinmaster/Mint", nil)
-	cdc.RegisterConcrete(&MsgBurn{}, "coinmaster/Burn", nil)
+	cdc.RegisterConcrete(&MsgCoinmasterMint{}, "coinmaster/Mint", nil)
+	cdc.RegisterConcrete(&MsgCoinmasterBurn{}, "coinmaster/Burn", nil)
 	// this line is used by starport scaffolding # 2
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
-		&MsgMint{},
+		&MsgCoinmasterMint{},
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
-		&MsgBurn{},
+		&MsgCoinmasterBurn{},
 	)
 	// this line is used by starport scaffolding # 3
 

--- a/x/coinmaster/types/errors.go
+++ b/x/coinmaster/types/errors.go
@@ -8,5 +8,7 @@ import (
 
 // x/coinmaster module sentinel errors
 var (
-	ErrSample = sdkerrors.Register(ModuleName, 1100, "sample error")
+	ErrCoinmasterMsg     = sdkerrors.Register(ModuleName, 1100, "invalid coinmaster message")
+	ErrCoinmasterMintMsg = sdkerrors.Register(ModuleName, 1101, "error with coinmaster Mint message")
+	ErrCoinmasterBurnMsg = sdkerrors.Register(ModuleName, 1102, "error with coinmaster Burn message")
 )

--- a/x/coinmaster/types/errors.go
+++ b/x/coinmaster/types/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrCoinmasterMsg     = sdkerrors.Register(ModuleName, 1100, "invalid coinmaster message")
 	ErrCoinmasterMintMsg = sdkerrors.Register(ModuleName, 1101, "error with coinmaster Mint message")
 	ErrCoinmasterBurnMsg = sdkerrors.Register(ModuleName, 1102, "error with coinmaster Burn message")
+	ErrCoinmasterQuery   = sdkerrors.Register(ModuleName, 1103, "error with coinmaster query")
 )

--- a/x/coinmaster/types/message_burn.go
+++ b/x/coinmaster/types/message_burn.go
@@ -5,26 +5,26 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const TypeMsgBurn = "burn"
+const TypeMsgCoinmasterBurn = "burn"
 
-var _ sdk.Msg = &MsgBurn{}
+var _ sdk.Msg = &MsgCoinmasterBurn{}
 
-func NewMsgBurn(creator string, amount sdk.Coin) *MsgBurn {
-	return &MsgBurn{
+func NewMsgCoinmasterBurn(creator string, amount sdk.Coin) *MsgCoinmasterBurn {
+	return &MsgCoinmasterBurn{
 		Creator: creator,
 		Amount:  amount,
 	}
 }
 
-func (msg *MsgBurn) Route() string {
+func (msg *MsgCoinmasterBurn) Route() string {
 	return RouterKey
 }
 
-func (msg *MsgBurn) Type() string {
-	return TypeMsgBurn
+func (msg *MsgCoinmasterBurn) Type() string {
+	return TypeMsgCoinmasterBurn
 }
 
-func (msg *MsgBurn) GetSigners() []sdk.AccAddress {
+func (msg *MsgCoinmasterBurn) GetSigners() []sdk.AccAddress {
 	creator, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		panic(err)
@@ -32,12 +32,12 @@ func (msg *MsgBurn) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{creator}
 }
 
-func (msg *MsgBurn) GetSignBytes() []byte {
+func (msg *MsgCoinmasterBurn) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
-func (msg *MsgBurn) ValidateBasic() error {
+func (msg *MsgCoinmasterBurn) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)

--- a/x/coinmaster/types/message_burn_test.go
+++ b/x/coinmaster/types/message_burn_test.go
@@ -8,21 +8,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMsgBurn_ValidateBasic(t *testing.T) {
+func TestMsgCoinmasterBurn_ValidateBasic(t *testing.T) {
 	tests := []struct {
 		name string
-		msg  MsgBurn
+		msg  MsgCoinmasterBurn
 		err  error
 	}{
 		{
 			name: "invalid address",
-			msg: MsgBurn{
+			msg: MsgCoinmasterBurn{
 				Creator: "invalid_address",
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "valid address",
-			msg: MsgBurn{
+			msg: MsgCoinmasterBurn{
 				Creator: sample.AccAddress(),
 			},
 		},

--- a/x/coinmaster/types/message_mint.go
+++ b/x/coinmaster/types/message_mint.go
@@ -5,26 +5,26 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const TypeMsgMint = "mint"
+const TypeMsgCoinmasterMint = "mint"
 
-var _ sdk.Msg = &MsgMint{}
+var _ sdk.Msg = &MsgCoinmasterMint{}
 
-func NewMsgMint(creator string, amount sdk.Coin) *MsgMint {
-	return &MsgMint{
+func NewMsgCoinmasterMint(creator string, amount sdk.Coin) *MsgCoinmasterMint {
+	return &MsgCoinmasterMint{
 		Creator: creator,
 		Amount:  amount,
 	}
 }
 
-func (msg *MsgMint) Route() string {
+func (msg *MsgCoinmasterMint) Route() string {
 	return RouterKey
 }
 
-func (msg *MsgMint) Type() string {
-	return TypeMsgMint
+func (msg *MsgCoinmasterMint) Type() string {
+	return TypeMsgCoinmasterMint
 }
 
-func (msg *MsgMint) GetSigners() []sdk.AccAddress {
+func (msg *MsgCoinmasterMint) GetSigners() []sdk.AccAddress {
 	creator, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		panic(err)
@@ -32,12 +32,12 @@ func (msg *MsgMint) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{creator}
 }
 
-func (msg *MsgMint) GetSignBytes() []byte {
+func (msg *MsgCoinmasterMint) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
-func (msg *MsgMint) ValidateBasic() error {
+func (msg *MsgCoinmasterMint) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)

--- a/x/coinmaster/types/message_mint_test.go
+++ b/x/coinmaster/types/message_mint_test.go
@@ -8,21 +8,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMsgMint_ValidateBasic(t *testing.T) {
+func TestMsgCoinmasterMint_ValidateBasic(t *testing.T) {
 	tests := []struct {
 		name string
-		msg  MsgMint
+		msg  MsgCoinmasterMint
 		err  error
 	}{
 		{
 			name: "invalid address",
-			msg: MsgMint{
+			msg: MsgCoinmasterMint{
 				Creator: "invalid_address",
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "valid address",
-			msg: MsgMint{
+			msg: MsgCoinmasterMint{
 				Creator: sample.AccAddress(),
 			},
 		},

--- a/x/coinmaster/types/tx.pb.go
+++ b/x/coinmaster/types/tx.pb.go
@@ -29,23 +29,23 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type MsgMint struct {
+type MsgCoinmasterMint struct {
 	Creator string     `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
 	Amount  types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount"`
 }
 
-func (m *MsgMint) Reset()         { *m = MsgMint{} }
-func (m *MsgMint) String() string { return proto.CompactTextString(m) }
-func (*MsgMint) ProtoMessage()    {}
-func (*MsgMint) Descriptor() ([]byte, []int) {
+func (m *MsgCoinmasterMint) Reset()         { *m = MsgCoinmasterMint{} }
+func (m *MsgCoinmasterMint) String() string { return proto.CompactTextString(m) }
+func (*MsgCoinmasterMint) ProtoMessage()    {}
+func (*MsgCoinmasterMint) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2f68783d02bba24b, []int{0}
 }
-func (m *MsgMint) XXX_Unmarshal(b []byte) error {
+func (m *MsgCoinmasterMint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgMint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgCoinmasterMint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgMint.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgCoinmasterMint.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -55,47 +55,47 @@ func (m *MsgMint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *MsgMint) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgMint.Merge(m, src)
+func (m *MsgCoinmasterMint) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCoinmasterMint.Merge(m, src)
 }
-func (m *MsgMint) XXX_Size() int {
+func (m *MsgCoinmasterMint) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgMint) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgMint.DiscardUnknown(m)
+func (m *MsgCoinmasterMint) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCoinmasterMint.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgMint proto.InternalMessageInfo
+var xxx_messageInfo_MsgCoinmasterMint proto.InternalMessageInfo
 
-func (m *MsgMint) GetCreator() string {
+func (m *MsgCoinmasterMint) GetCreator() string {
 	if m != nil {
 		return m.Creator
 	}
 	return ""
 }
 
-func (m *MsgMint) GetAmount() types.Coin {
+func (m *MsgCoinmasterMint) GetAmount() types.Coin {
 	if m != nil {
 		return m.Amount
 	}
 	return types.Coin{}
 }
 
-type MsgMintResponse struct {
+type MsgCoinmasterMintResponse struct {
 }
 
-func (m *MsgMintResponse) Reset()         { *m = MsgMintResponse{} }
-func (m *MsgMintResponse) String() string { return proto.CompactTextString(m) }
-func (*MsgMintResponse) ProtoMessage()    {}
-func (*MsgMintResponse) Descriptor() ([]byte, []int) {
+func (m *MsgCoinmasterMintResponse) Reset()         { *m = MsgCoinmasterMintResponse{} }
+func (m *MsgCoinmasterMintResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgCoinmasterMintResponse) ProtoMessage()    {}
+func (*MsgCoinmasterMintResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2f68783d02bba24b, []int{1}
 }
-func (m *MsgMintResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgCoinmasterMintResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgMintResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgCoinmasterMintResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgMintResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgCoinmasterMintResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -105,35 +105,35 @@ func (m *MsgMintResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
-func (m *MsgMintResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgMintResponse.Merge(m, src)
+func (m *MsgCoinmasterMintResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCoinmasterMintResponse.Merge(m, src)
 }
-func (m *MsgMintResponse) XXX_Size() int {
+func (m *MsgCoinmasterMintResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgMintResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgMintResponse.DiscardUnknown(m)
+func (m *MsgCoinmasterMintResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCoinmasterMintResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgMintResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgCoinmasterMintResponse proto.InternalMessageInfo
 
-type MsgBurn struct {
+type MsgCoinmasterBurn struct {
 	Creator string     `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
 	Amount  types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount"`
 }
 
-func (m *MsgBurn) Reset()         { *m = MsgBurn{} }
-func (m *MsgBurn) String() string { return proto.CompactTextString(m) }
-func (*MsgBurn) ProtoMessage()    {}
-func (*MsgBurn) Descriptor() ([]byte, []int) {
+func (m *MsgCoinmasterBurn) Reset()         { *m = MsgCoinmasterBurn{} }
+func (m *MsgCoinmasterBurn) String() string { return proto.CompactTextString(m) }
+func (*MsgCoinmasterBurn) ProtoMessage()    {}
+func (*MsgCoinmasterBurn) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2f68783d02bba24b, []int{2}
 }
-func (m *MsgBurn) XXX_Unmarshal(b []byte) error {
+func (m *MsgCoinmasterBurn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgBurn) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgCoinmasterBurn) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgBurn.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgCoinmasterBurn.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -143,47 +143,47 @@ func (m *MsgBurn) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *MsgBurn) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgBurn.Merge(m, src)
+func (m *MsgCoinmasterBurn) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCoinmasterBurn.Merge(m, src)
 }
-func (m *MsgBurn) XXX_Size() int {
+func (m *MsgCoinmasterBurn) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgBurn) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgBurn.DiscardUnknown(m)
+func (m *MsgCoinmasterBurn) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCoinmasterBurn.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgBurn proto.InternalMessageInfo
+var xxx_messageInfo_MsgCoinmasterBurn proto.InternalMessageInfo
 
-func (m *MsgBurn) GetCreator() string {
+func (m *MsgCoinmasterBurn) GetCreator() string {
 	if m != nil {
 		return m.Creator
 	}
 	return ""
 }
 
-func (m *MsgBurn) GetAmount() types.Coin {
+func (m *MsgCoinmasterBurn) GetAmount() types.Coin {
 	if m != nil {
 		return m.Amount
 	}
 	return types.Coin{}
 }
 
-type MsgBurnResponse struct {
+type MsgCoinmasterBurnResponse struct {
 }
 
-func (m *MsgBurnResponse) Reset()         { *m = MsgBurnResponse{} }
-func (m *MsgBurnResponse) String() string { return proto.CompactTextString(m) }
-func (*MsgBurnResponse) ProtoMessage()    {}
-func (*MsgBurnResponse) Descriptor() ([]byte, []int) {
+func (m *MsgCoinmasterBurnResponse) Reset()         { *m = MsgCoinmasterBurnResponse{} }
+func (m *MsgCoinmasterBurnResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgCoinmasterBurnResponse) ProtoMessage()    {}
+func (*MsgCoinmasterBurnResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2f68783d02bba24b, []int{3}
 }
-func (m *MsgBurnResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgCoinmasterBurnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgBurnResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgCoinmasterBurnResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgBurnResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgCoinmasterBurnResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -193,48 +193,48 @@ func (m *MsgBurnResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
-func (m *MsgBurnResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgBurnResponse.Merge(m, src)
+func (m *MsgCoinmasterBurnResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCoinmasterBurnResponse.Merge(m, src)
 }
-func (m *MsgBurnResponse) XXX_Size() int {
+func (m *MsgCoinmasterBurnResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgBurnResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgBurnResponse.DiscardUnknown(m)
+func (m *MsgCoinmasterBurnResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCoinmasterBurnResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgBurnResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgCoinmasterBurnResponse proto.InternalMessageInfo
 
 func init() {
-	proto.RegisterType((*MsgMint)(nil), "norianet.noria.coinmaster.MsgMint")
-	proto.RegisterType((*MsgMintResponse)(nil), "norianet.noria.coinmaster.MsgMintResponse")
-	proto.RegisterType((*MsgBurn)(nil), "norianet.noria.coinmaster.MsgBurn")
-	proto.RegisterType((*MsgBurnResponse)(nil), "norianet.noria.coinmaster.MsgBurnResponse")
+	proto.RegisterType((*MsgCoinmasterMint)(nil), "norianet.noria.coinmaster.MsgCoinmasterMint")
+	proto.RegisterType((*MsgCoinmasterMintResponse)(nil), "norianet.noria.coinmaster.MsgCoinmasterMintResponse")
+	proto.RegisterType((*MsgCoinmasterBurn)(nil), "norianet.noria.coinmaster.MsgCoinmasterBurn")
+	proto.RegisterType((*MsgCoinmasterBurnResponse)(nil), "norianet.noria.coinmaster.MsgCoinmasterBurnResponse")
 }
 
 func init() { proto.RegisterFile("coinmaster/tx.proto", fileDescriptor_2f68783d02bba24b) }
 
 var fileDescriptor_2f68783d02bba24b = []byte{
-	// 302 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x92, 0xb1, 0x4e, 0xf3, 0x30,
-	0x14, 0x85, 0xe3, 0xff, 0xaf, 0x5a, 0x61, 0x06, 0x44, 0x60, 0x68, 0x33, 0x98, 0x2a, 0x53, 0x85,
-	0x54, 0x5b, 0x2d, 0x03, 0x7b, 0x18, 0x98, 0xb2, 0x64, 0x60, 0x40, 0x2c, 0x4e, 0x64, 0x85, 0x0c,
-	0xf1, 0x8d, 0x6c, 0x07, 0x95, 0xb7, 0xe0, 0x65, 0x78, 0x87, 0x8e, 0x1d, 0x99, 0x10, 0x4a, 0x5e,
-	0x04, 0xd9, 0x49, 0x44, 0x17, 0x94, 0x89, 0xed, 0xd8, 0x3e, 0xfe, 0xce, 0xbd, 0xf6, 0xc5, 0x17,
-	0x19, 0x14, 0xb2, 0xe4, 0xda, 0x08, 0xc5, 0xcc, 0x8e, 0x56, 0x0a, 0x0c, 0xf8, 0x0b, 0x09, 0xaa,
-	0xe0, 0x52, 0x18, 0xea, 0x04, 0xfd, 0xf1, 0x04, 0x24, 0x03, 0x5d, 0x82, 0x66, 0x29, 0xd7, 0x82,
-	0xbd, 0x6c, 0x52, 0x61, 0xf8, 0x86, 0xd9, 0xf3, 0xee, 0x6a, 0x70, 0x99, 0x43, 0x0e, 0x4e, 0x32,
-	0xab, 0xba, 0xdd, 0xf0, 0x09, 0xcf, 0x62, 0x9d, 0xc7, 0x85, 0x34, 0xfe, 0x1c, 0xcf, 0x32, 0x25,
-	0xb8, 0x01, 0x35, 0x47, 0x4b, 0xb4, 0x3a, 0x49, 0x86, 0xa5, 0x7f, 0x8b, 0xa7, 0xbc, 0x84, 0x5a,
-	0x9a, 0xf9, 0xbf, 0x25, 0x5a, 0x9d, 0x6e, 0x17, 0xb4, 0xcb, 0xa2, 0x36, 0x8b, 0xf6, 0x59, 0xf4,
-	0x0e, 0x0a, 0x19, 0x4d, 0xf6, 0x9f, 0x57, 0x5e, 0xd2, 0xdb, 0xc3, 0x73, 0x7c, 0xd6, 0xd3, 0x13,
-	0xa1, 0x2b, 0x90, 0x5a, 0xf4, 0x81, 0x51, 0xad, 0xe4, 0xdf, 0x05, 0x5a, 0xfa, 0x10, 0xb8, 0x7d,
-	0x47, 0xf8, 0x7f, 0xac, 0x73, 0xff, 0x01, 0x4f, 0x5c, 0x9b, 0x21, 0xfd, 0xf5, 0x0d, 0x69, 0x5f,
-	0x6c, 0x70, 0x3d, 0xee, 0x19, 0xf8, 0x96, 0xeb, 0xba, 0x19, 0xe1, 0x5a, 0xcf, 0x18, 0xf7, 0xb8,
-	0xee, 0xe8, 0x7e, 0xdf, 0x10, 0x74, 0x68, 0x08, 0xfa, 0x6a, 0x08, 0x7a, 0x6b, 0x89, 0x77, 0x68,
-	0x89, 0xf7, 0xd1, 0x12, 0xef, 0x71, 0x9d, 0x17, 0xe6, 0xb9, 0x4e, 0x69, 0x06, 0x25, 0x73, 0x98,
-	0xb5, 0x14, 0xa6, 0x53, 0x6c, 0xc7, 0x8e, 0xc7, 0xe6, 0xb5, 0x12, 0x3a, 0x9d, 0xba, 0x9f, 0xbe,
-	0xf9, 0x0e, 0x00, 0x00, 0xff, 0xff, 0xae, 0xbd, 0x8d, 0x9e, 0x51, 0x02, 0x00, 0x00,
+	// 304 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x92, 0xb1, 0x4e, 0xf3, 0x30,
+	0x14, 0x85, 0xe3, 0xff, 0xaf, 0x8a, 0x30, 0x13, 0x81, 0xa1, 0x0d, 0x92, 0xa9, 0x3a, 0x75, 0xa0,
+	0xb6, 0x5a, 0x90, 0xd8, 0xc3, 0xc0, 0x94, 0x25, 0x23, 0x9b, 0x13, 0x99, 0x10, 0xa4, 0xf8, 0x46,
+	0xb6, 0x83, 0xca, 0x5b, 0xf0, 0x58, 0x1d, 0x3b, 0xb2, 0x80, 0x50, 0xf2, 0x22, 0xc8, 0x4e, 0x03,
+	0x95, 0x22, 0xa4, 0xb2, 0xb0, 0x1d, 0xdb, 0xc7, 0xf7, 0xbb, 0xe7, 0xea, 0xe2, 0x93, 0x14, 0x72,
+	0x59, 0x70, 0x6d, 0x84, 0x62, 0x66, 0x45, 0x4b, 0x05, 0x06, 0xfc, 0xb1, 0x04, 0x95, 0x73, 0x29,
+	0x0c, 0x75, 0x82, 0x7e, 0x7b, 0x02, 0x92, 0x82, 0x2e, 0x40, 0xb3, 0x84, 0x6b, 0xc1, 0x9e, 0x16,
+	0x89, 0x30, 0x7c, 0xc1, 0xec, 0x7b, 0xfb, 0x35, 0x38, 0xcd, 0x20, 0x03, 0x27, 0x99, 0x55, 0xed,
+	0xed, 0xf4, 0x1e, 0x1f, 0x47, 0x3a, 0xbb, 0xf9, 0x2a, 0x13, 0xe5, 0xd2, 0xf8, 0x23, 0x7c, 0x90,
+	0x2a, 0xc1, 0x0d, 0xa8, 0x11, 0x9a, 0xa0, 0xd9, 0x61, 0xdc, 0x1d, 0xfd, 0x6b, 0x3c, 0xe4, 0x05,
+	0x54, 0xd2, 0x8c, 0xfe, 0x4d, 0xd0, 0xec, 0x68, 0x39, 0xa6, 0x2d, 0x95, 0x5a, 0x2a, 0xdd, 0x52,
+	0xa9, 0x2d, 0x17, 0x0e, 0xd6, 0xef, 0xe7, 0x5e, 0xbc, 0xb5, 0x4f, 0xcf, 0xf0, 0xb8, 0xc7, 0x89,
+	0x85, 0x2e, 0x41, 0x6a, 0xd1, 0x6b, 0x22, 0xac, 0x94, 0xfc, 0x8b, 0x26, 0x2c, 0xa7, 0x6b, 0x62,
+	0xf9, 0x86, 0xf0, 0xff, 0x48, 0x67, 0xfe, 0x23, 0x1e, 0xb8, 0x21, 0x5c, 0xd0, 0x1f, 0x67, 0x4d,
+	0x7b, 0x51, 0x82, 0xab, 0xdf, 0xb8, 0x3b, 0xa6, 0x65, 0xb9, 0xac, 0x7b, 0xb3, 0xac, 0x7b, 0x7f,
+	0xd6, 0x6e, 0xbe, 0xf0, 0x76, 0x5d, 0x13, 0xb4, 0xa9, 0x09, 0xfa, 0xa8, 0x09, 0x7a, 0x69, 0x88,
+	0xb7, 0x69, 0x88, 0xf7, 0xda, 0x10, 0xef, 0x6e, 0x9e, 0xe5, 0xe6, 0xa1, 0x4a, 0x68, 0x0a, 0x05,
+	0x73, 0x05, 0xe7, 0x52, 0x98, 0x56, 0xb1, 0x15, 0xdb, 0x5d, 0xc3, 0xe7, 0x52, 0xe8, 0x64, 0xe8,
+	0x36, 0xe7, 0xf2, 0x33, 0x00, 0x00, 0xff, 0xff, 0x7d, 0x48, 0x8f, 0x08, 0xa1, 0x02, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -249,8 +249,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
-	Mint(ctx context.Context, in *MsgMint, opts ...grpc.CallOption) (*MsgMintResponse, error)
-	Burn(ctx context.Context, in *MsgBurn, opts ...grpc.CallOption) (*MsgBurnResponse, error)
+	Mint(ctx context.Context, in *MsgCoinmasterMint, opts ...grpc.CallOption) (*MsgCoinmasterMintResponse, error)
+	Burn(ctx context.Context, in *MsgCoinmasterBurn, opts ...grpc.CallOption) (*MsgCoinmasterBurnResponse, error)
 }
 
 type msgClient struct {
@@ -261,8 +261,8 @@ func NewMsgClient(cc grpc1.ClientConn) MsgClient {
 	return &msgClient{cc}
 }
 
-func (c *msgClient) Mint(ctx context.Context, in *MsgMint, opts ...grpc.CallOption) (*MsgMintResponse, error) {
-	out := new(MsgMintResponse)
+func (c *msgClient) Mint(ctx context.Context, in *MsgCoinmasterMint, opts ...grpc.CallOption) (*MsgCoinmasterMintResponse, error) {
+	out := new(MsgCoinmasterMintResponse)
 	err := c.cc.Invoke(ctx, "/norianet.noria.coinmaster.Msg/Mint", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -270,8 +270,8 @@ func (c *msgClient) Mint(ctx context.Context, in *MsgMint, opts ...grpc.CallOpti
 	return out, nil
 }
 
-func (c *msgClient) Burn(ctx context.Context, in *MsgBurn, opts ...grpc.CallOption) (*MsgBurnResponse, error) {
-	out := new(MsgBurnResponse)
+func (c *msgClient) Burn(ctx context.Context, in *MsgCoinmasterBurn, opts ...grpc.CallOption) (*MsgCoinmasterBurnResponse, error) {
+	out := new(MsgCoinmasterBurnResponse)
 	err := c.cc.Invoke(ctx, "/norianet.noria.coinmaster.Msg/Burn", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -281,18 +281,18 @@ func (c *msgClient) Burn(ctx context.Context, in *MsgBurn, opts ...grpc.CallOpti
 
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
-	Mint(context.Context, *MsgMint) (*MsgMintResponse, error)
-	Burn(context.Context, *MsgBurn) (*MsgBurnResponse, error)
+	Mint(context.Context, *MsgCoinmasterMint) (*MsgCoinmasterMintResponse, error)
+	Burn(context.Context, *MsgCoinmasterBurn) (*MsgCoinmasterBurnResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
 type UnimplementedMsgServer struct {
 }
 
-func (*UnimplementedMsgServer) Mint(ctx context.Context, req *MsgMint) (*MsgMintResponse, error) {
+func (*UnimplementedMsgServer) Mint(ctx context.Context, req *MsgCoinmasterMint) (*MsgCoinmasterMintResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Mint not implemented")
 }
-func (*UnimplementedMsgServer) Burn(ctx context.Context, req *MsgBurn) (*MsgBurnResponse, error) {
+func (*UnimplementedMsgServer) Burn(ctx context.Context, req *MsgCoinmasterBurn) (*MsgCoinmasterBurnResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Burn not implemented")
 }
 
@@ -301,7 +301,7 @@ func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
 }
 
 func _Msg_Mint_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(MsgMint)
+	in := new(MsgCoinmasterMint)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -313,13 +313,13 @@ func _Msg_Mint_Handler(srv interface{}, ctx context.Context, dec func(interface{
 		FullMethod: "/norianet.noria.coinmaster.Msg/Mint",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServer).Mint(ctx, req.(*MsgMint))
+		return srv.(MsgServer).Mint(ctx, req.(*MsgCoinmasterMint))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _Msg_Burn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(MsgBurn)
+	in := new(MsgCoinmasterBurn)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func _Msg_Burn_Handler(srv interface{}, ctx context.Context, dec func(interface{
 		FullMethod: "/norianet.noria.coinmaster.Msg/Burn",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServer).Burn(ctx, req.(*MsgBurn))
+		return srv.(MsgServer).Burn(ctx, req.(*MsgCoinmasterBurn))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -353,7 +353,7 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 	Metadata: "coinmaster/tx.proto",
 }
 
-func (m *MsgMint) Marshal() (dAtA []byte, err error) {
+func (m *MsgCoinmasterMint) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -363,12 +363,12 @@ func (m *MsgMint) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgMint) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterMint) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgMint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterMint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -393,7 +393,7 @@ func (m *MsgMint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgMintResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgCoinmasterMintResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -403,12 +403,12 @@ func (m *MsgMintResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgMintResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterMintResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgMintResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterMintResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -416,7 +416,7 @@ func (m *MsgMintResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgBurn) Marshal() (dAtA []byte, err error) {
+func (m *MsgCoinmasterBurn) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -426,12 +426,12 @@ func (m *MsgBurn) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgBurn) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterBurn) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgBurn) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterBurn) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -456,7 +456,7 @@ func (m *MsgBurn) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgBurnResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgCoinmasterBurnResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -466,12 +466,12 @@ func (m *MsgBurnResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgBurnResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterBurnResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgBurnResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgCoinmasterBurnResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -490,7 +490,7 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *MsgMint) Size() (n int) {
+func (m *MsgCoinmasterMint) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -505,7 +505,7 @@ func (m *MsgMint) Size() (n int) {
 	return n
 }
 
-func (m *MsgMintResponse) Size() (n int) {
+func (m *MsgCoinmasterMintResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -514,7 +514,7 @@ func (m *MsgMintResponse) Size() (n int) {
 	return n
 }
 
-func (m *MsgBurn) Size() (n int) {
+func (m *MsgCoinmasterBurn) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -529,7 +529,7 @@ func (m *MsgBurn) Size() (n int) {
 	return n
 }
 
-func (m *MsgBurnResponse) Size() (n int) {
+func (m *MsgCoinmasterBurnResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -544,7 +544,7 @@ func sovTx(x uint64) (n int) {
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *MsgMint) Unmarshal(dAtA []byte) error {
+func (m *MsgCoinmasterMint) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -567,10 +567,10 @@ func (m *MsgMint) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgMint: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgCoinmasterMint: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgMint: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgCoinmasterMint: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -659,7 +659,7 @@ func (m *MsgMint) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgMintResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgCoinmasterMintResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -682,10 +682,10 @@ func (m *MsgMintResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgMintResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgCoinmasterMintResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgMintResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgCoinmasterMintResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -709,7 +709,7 @@ func (m *MsgMintResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgBurn) Unmarshal(dAtA []byte) error {
+func (m *MsgCoinmasterBurn) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -732,10 +732,10 @@ func (m *MsgBurn) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgBurn: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgCoinmasterBurn: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgBurn: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgCoinmasterBurn: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -824,7 +824,7 @@ func (m *MsgBurn) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgBurnResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgCoinmasterBurnResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -847,10 +847,10 @@ func (m *MsgBurnResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgBurnResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgCoinmasterBurnResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgBurnResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgCoinmasterBurnResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/x/coinmaster/types/types.go
+++ b/x/coinmaster/types/types.go
@@ -17,16 +17,21 @@ type CoinmasterSubMsg struct {
 }
 
 type CoinmasterQuery struct {
-	Coinmaster *CoinmasterSubQuery `json:"coinmaster,omitempty"`
+	Coinmaster *CoinmasterSubQuery `json:"coinmaster"`
 }
 
 // See https://github.com/CosmWasm/token-bindings/blob/main/packages/bindings/src/query.rs
 type CoinmasterSubQuery struct {
-	Params *GetParams `json:"params,omitempty"`
+	Params *GetParams `json:"params"`
 }
 
 type GetParams struct{}
 
+type ParamsProperties struct {
+	Minters string `json:"minters"`
+	Denoms  string `json:"denoms"`
+}
+
 type ParamsResponse struct {
-	Params Params `json:"params"`
+	Params ParamsProperties `json:"params"`
 }

--- a/x/coinmaster/types/types.go
+++ b/x/coinmaster/types/types.go
@@ -1,1 +1,32 @@
 package types
+
+type CoinmasterMsg struct {
+	Coinmaster *CoinmasterSubMsg `json:"coinmaster,omitempty"`
+}
+
+type MsgCustomCoinmasterMint struct {
+	Amount string `json:"amount,omitempty"`
+}
+
+type MsgCustomCoinmasterBurn struct {
+	Amount string `json:"amount,omitempty"`
+}
+type CoinmasterSubMsg struct {
+	Mint *MsgCustomCoinmasterMint `json:"mint,omitempty"`
+	Burn *MsgCustomCoinmasterBurn `json:"burn,omitempty"`
+}
+
+type CoinmasterQuery struct {
+	Coinmaster *CoinmasterSubQuery `json:"coinmaster,omitempty"`
+}
+
+// See https://github.com/CosmWasm/token-bindings/blob/main/packages/bindings/src/query.rs
+type CoinmasterSubQuery struct {
+	Params *GetParams `json:"params,omitempty"`
+}
+
+type GetParams struct{}
+
+type ParamsResponse struct {
+	Params Params `json:"params"`
+}

--- a/x/coinmaster/wasm/interface.go
+++ b/x/coinmaster/wasm/interface.go
@@ -30,16 +30,18 @@ func NewWasmMsgParser() WasmMsgParser {
 
 // CosmosMsg only contains mint and burn msg
 type CosmosMsg struct {
-	Mint *types.MsgMint `json:"mint,omitempty"`
-	Burn *types.MsgBurn `json:"burn,omitempty"`
+	Coinmaster *CoinmasterMsg `json:"coinmaster,omitempty"`
+}
+type CoinmasterMsg struct {
+	Mint *types.MsgCoinmasterMint `json:"mint,omitempty"`
+	Burn *types.MsgCoinmasterBurn `json:"burn,omitempty"`
 }
 
 // ParseCustom implements custom parser
 func (WasmMsgParser) ParseCustom(contractAddr sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
-	var sdkMsg CosmosMsg
-	err := json.Unmarshal(msg, &sdkMsg)
-	if err != nil {
-		return nil, sdkerrors.Wrap(err, "failed to parse market custom msg")
+	var sdkMsg CoinmasterMsg
+	if err := json.Unmarshal(msg, &sdkMsg); err != nil {
+		return nil, sdkerrors.Wrap(ErrInvalidMsg, "Invalid Coinmaster Msg")
 	}
 
 	if sdkMsg.Mint != nil {


### PR DESCRIPTION
## Meta  

Notion task: https://www.notion.so/92bddda861cd41a38ec8c2aa9c5d69d0?v=116d739390814b2e97702e668fcc601b&p=d8d828fb6b454b5fbecf229553c11b18&pm=s

Closing #12 and #13 

## Changelog  
- new wasm bindings supporting cosmwasm_std standard

> This is API breaking for smart contract developers. See [Coinmaster README](https://github.com/noria-net/noria/blob/a442210ba6831b79cf3a458138228b485f210f7a/x/coinmaster/README.md)  

- new coinmaster params unit test for `SetParams` validation
- renamed coinmaster messages to avoid message collision check in Cosmos SDK 47

> MsgMint -> MsgCoinmasterMint
> MsgBurn -> MsgCoinmasterBurn

- Coinmaster now supports multiple whitelisted minters, including support for smart contracts.

## Tests

- v1.0.0 -> this PR is green
- All `/x/coinmaster` tests passing green

## Tag

I believe this PR can be merged with main and be tagged for the next `v1.1.0` release. 
