### PR TITLE
build: add package and validate targets to simplify binary releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,18 @@ build:
 	echo $(BUILD_FLAGS)
 	go build $(BUILD_FLAGS) -o ./build/noriad ./cmd/noriad
 
+package:
+	echo "Packaging noriad $(VERSION)"
+	mkdir -p release/$(VERSION)
+	tar -czvf release/$(VERSION)/noria_linux_amd64.tar.gz --transform='s,^build/,,' build/noriad
+	cd release/$(VERSION); \
+	sha256sum noria_linux_amd64.tar.gz > sha256.txt; \
+	cat sha256.txt
+
+validate_sha256:
+	cd release/$(VERSION); \
+	sha256sum -c sha256.txt
+
 clean:
 	rm -rf \
 		$(BUILDDIR)/ \

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ clean:
 rebuild: clean build
 
 docker-build:
-	$(DOCKER) build -f ./docker/Dockerfile.build -t noria\:$(VERSION) .; \
+	$(DOCKER) build -f ./docker/Dockerfile.build -t noria\:$(VERSION) . --network host; \
 	$(DOCKER) run --rm -v $(CURDIR)\:/code noria\:$(VERSION) make build;
 
 docker-test:

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.15 AS go-builder
+FROM golang:1.20.4-alpine3.18 AS go-builder
 ARG arch=x86_64
 RUN set -eux; apk add --no-cache ca-certificates build-base;
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-buster
+FROM golang:1.20.4-buster
 SHELL ["/bin/bash", "-c"]
 COPY ./build/noriad /usr/bin/noriad
 


### PR DESCRIPTION
Added two extra Makefile targets to simplify release packaging and validation:

- `make package` will create an archive and a sha256 in `release/$(VERSION)/`
- `make validate_sha256` will validate that the archive's hash matches `release/$(VERSION)/sha256.txt`