### PR TITLE
Jumpdest7d/update chain upgrade script

### DIFF
--- a/dev/scripts/chain_upgrade.sh
+++ b/dev/scripts/chain_upgrade.sh
@@ -29,7 +29,7 @@ if [ -z "$1" ] || [ -z "$2" ] || [ -z "$NODE" ]; then
 fi
 
 # submit upgrade proposal
-$DAEMON_NAME tx gov submit-proposal software-upgrade $UPGRADE_NAME \
+$DAEMON_NAME tx gov submit-legacy-proposal software-upgrade $UPGRADE_NAME \
   --title "Upgrade to $UPGRADE_NAME" \
   --description "Upgrade to $UPGRADE_NAME" \
   --upgrade-info="{\"binaries\":{\"linux/amd64\":\"$BINARY_DOWNLOAD_URL\"}}" \

--- a/dev/scripts/chain_upgrade.sh
+++ b/dev/scripts/chain_upgrade.sh
@@ -43,10 +43,17 @@ $DAEMON_NAME tx gov submit-legacy-proposal software-upgrade $UPGRADE_NAME \
   --gas-prices $GAS_PRICE$GAS_PRICE_DENOM \
   --gas auto \
   --gas-adjustment 1.5 \
-  --broadcast-mode block
 
 PROPOSAL_ID=$($DAEMON_NAME q gov proposals limit 1 --reverse --output json --home $DAEMON_HOME --node "$NODE" | jq '.proposals[0].proposal_id | tonumber')
 
 # vote on the proposal
-$DAEMON_NAME tx gov vote $PROPOSAL_ID yes --from $KEY_NAME --chain-id $CHAIN_ID --home $DAEMON_HOME --node $NODE --yes --gas-prices $GAS_PRICE$GAS_PRICE_DENOM --gas auto --gas-adjustment 1.5 --broadcast-mode block
+$DAEMON_NAME tx gov vote $PROPOSAL_ID yes \
+  --from $KEY_NAME \
+  --chain-id $CHAIN_ID \
+  --home $DAEMON_HOME \
+  --node $NODE \
+  --yes \
+  --gas-prices $GAS_PRICE$GAS_PRICE_DENOM \
+  --gas auto \
+  --gas-adjustment 1.5
 


### PR DESCRIPTION
* Updated `chain_upgrade.sh` to call the legacy submit proposal tx, since we haven't switched over to using a proposal file yet.
* Removed the `--broadcast-mode` flags from submission and voting tx calls.