### PR TITLE
Added cleveldb support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifeq ($(LEDGER_ENABLED),true)
 endif
 
 ifeq (cleveldb,$(findstring cleveldb,$(COSMOS_BUILD_OPTIONS)))
-	build_tags += gcc
+	build_tags += gcc cleveldb
 endif
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))


### PR DESCRIPTION
# META

A simple modification to the Makefile to allow proper support for cleveldb. This will help improve the performance of nodes, especially archival nodes.

# Changelog  

- Makefile, a simple additional build tag

# Notes

Not a state breaking change, can be tagged up without proposal.